### PR TITLE
add ability to specify key vault managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This module will deploy hashicorp vault into a pre-existing AKS cluster
 |------|-------------|------|---------|:-----:|
 | additional\_yaml\_config | yaml config for helm chart to be processed last | `string` | `""` | no |
 | identity\_name | name for Azure identity to be used by AAD | `string` | `"aks-aad"` | no |
+| key\_vault\_managers | Azure identities/groups to be granted management access to Azure Key Vault (leave empty for object\_id running terraform) | <pre>map(object({<br>                  tenant_id = string<br>                  object_id = string }))</pre> | n/a | yes |
 | kubernetes\_namespace | kubernetes namespace where vault will be installed | `string` | `"default"` | no |
 | kubernetes\_node\_selector | kubernetes node selector labels | `map(string)` | `{}` | no |
 | location | Azure Region | `string` | n/a | yes |

--- a/data_sources.tf
+++ b/data_sources.tf
@@ -1,5 +1,1 @@
 data "azurerm_client_config" "current" {}
-
-data "azurerm_resource_group" "rg" {
-  name = var.resource_group_name
-}

--- a/local.tf
+++ b/local.tf
@@ -1,0 +1,5 @@
+locals {
+  key_vault_managers = (var.key_vault_managers != null ? var.key_vault_managers :
+                       { current = { tenant_id = data.azurerm_client_config.current.tenant_id
+                                     object_id = data.azurerm_client_config.current.object_id }} )
+}

--- a/main.tf
+++ b/main.tf
@@ -25,12 +25,13 @@ resource "azurerm_key_vault" "kv" {
          })
 }
 
-resource "azurerm_key_vault_access_policy" "current" {
+resource "azurerm_key_vault_access_policy" "manager" {
+  for_each = local.key_vault_managers
 
   key_vault_id = azurerm_key_vault.kv.id
 
-  tenant_id = data.azurerm_client_config.current.tenant_id
-  object_id = data.azurerm_client_config.current.object_id
+  tenant_id = each.value.tenant_id
+  object_id = each.value.object_id
 
   key_permissions = [
     "create",
@@ -50,7 +51,7 @@ resource "azurerm_key_vault_access_policy" "current" {
 }
 
 resource "azurerm_key_vault_key" "generated" {
-  depends_on   = [azurerm_key_vault_access_policy.current]
+  depends_on   = [azurerm_key_vault_access_policy.manager]
   name         = "hashicorp-vault-key"
   key_vault_id = azurerm_key_vault.kv.id
   key_type     = "RSA"
@@ -69,7 +70,7 @@ resource "azurerm_key_vault_key" "generated" {
 }
 
 resource "azurerm_key_vault_secret" "vault_init" {
-  depends_on   = [azurerm_key_vault_access_policy.current]
+  depends_on   = [azurerm_key_vault_access_policy.manager]
   name         = "hashicorp-vault-init"
   value        = ""
   key_vault_id = azurerm_key_vault.kv.id

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,14 @@ variable "kubernetes_node_selector" {
   default     = {}
 }
 
+variable "key_vault_managers" {
+  description = "Azure identities/groups to be granted management access to Azure Key Vault (leave empty for object_id running terraform)"
+  type        = map(object({
+                  tenant_id = string
+                  object_id = string }))
+  default     = null
+}
+
 # AAD
 variable "identity_name" {
   description = "name for Azure identity to be used by AAD"


### PR DESCRIPTION
Fixes https://github.com/Azure-Terraform/terraform-azurerm-hashicorp-vault/issues/10

Addresses access issues when terraform runs as a temporary identity.